### PR TITLE
chore: standardize repository maintenance

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: ant-design
+open_collective: ant-design

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '21:00'
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 10
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+      time: '21:00'
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: 'CodeQL'
+
+on:
+  push:
+    branches: ['master']
+  pull_request:
+    branches: ['master']
+  schedule:
+    - cron: '36 13 * * 3'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: ✅ test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - run: npm install --legacy-peer-deps
+      - run: npm run compile
+      - run: npm run test:only

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) react-component
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">English | [简体中文](./README.zh-CN.md)</p>
+<p align="center">English | <a href="./README.zh-CN.md">简体中文</a></p>
 
 ## Highlights
 
@@ -43,18 +43,20 @@ npx rc-np
 ## Development
 
 ```bash
-npm install
+ut install
 npm run compile
 npm run test:only
 ```
 
 ## Release
 
+Maintainers can run the publish guard before releasing this package:
+
 ```bash
 npm run prepublishOnly
 ```
 
-This package is the release helper itself. `prepublishOnly` only verifies the build before publishing.
+This package is the release helper itself, so the guard only verifies the build before publishing.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npx rc-np
 ## Development
 
 ```bash
-ut install
+npm install
 npm run compile
 npm run test:only
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">简体中文 | <a href="./README.md">English</a></p>
+<p align="center"><a href="./README.md">English</a> | 简体中文</p>
 
 ## 亮点
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,7 +43,7 @@ npx rc-np
 ## 本地开发
 
 ```bash
-ut install
+npm install
 npm run compile
 npm run test:only
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 <div align="center">
   <h1>@rc-component/np</h1>
-  <p><sub><a href="https://ant.design"><img alt="Ant Design" height="14" src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg" style="vertical-align: -0.125em;" /></a> Part of the Ant Design ecosystem.</sub></p>
-  <p>🚀 Release helper for rc-component packages.</p>
+  <p><sub><a href="https://ant.design"><img alt="Ant Design" height="14" src="https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg" style="vertical-align: -0.125em;" /></a> Ant Design 生态的一部分。</sub></p>
+  <p>🚀 rc-component 包使用的发布辅助工具。</p>
 
   <p>
     <a href="https://npmjs.org/package/@rc-component/np"><img alt="NPM version" src="https://img.shields.io/npm/v/@rc-component/np.svg?style=flat-square"></a>
@@ -12,23 +12,23 @@
   </p>
 </div>
 
-<p align="center">English | [简体中文](./README.zh-CN.md)</p>
+<p align="center">简体中文 | [English](./README.md)</p>
 
-## Highlights
+## 亮点
 
-| Area    | Support                                   |
-| ------- | ----------------------------------------- |
-| Purpose | Release helper for rc-component packages. |
-| Package | `@rc-component/np`                        |
-| Release | `@rc-component/np` / `rc-np`              |
+| 方向 | 支持                                |
+| ---- | ----------------------------------- |
+| 定位 | rc-component 包使用的发布辅助工具。 |
+| 包名 | `@rc-component/np`                  |
+| 发布 | `@rc-component/np` / `rc-np`        |
 
-## Install
+## 安装
 
 ```bash
 npm install @rc-component/np --save-dev
 ```
 
-## Usage
+## 用法
 
 ```bash
 npx rc-np
@@ -36,11 +36,11 @@ npx rc-np
 
 ## API
 
-| Command | Description                        |
-| ------- | ---------------------------------- |
-| `rc-np` | Run the rc-component release flow. |
+| 名称    | 说明                         |
+| ------- | ---------------------------- |
+| `rc-np` | 运行 rc-component 发布流程。 |
 
-## Development
+## 本地开发
 
 ```bash
 npm install
@@ -48,14 +48,14 @@ npm run compile
 npm run test:only
 ```
 
-## Release
+## 发布
 
 ```bash
 npm run prepublishOnly
 ```
 
-This package is the release helper itself. `prepublishOnly` only verifies the build before publishing.
+这个包本身就是发布辅助工具，`prepublishOnly` 只在发布前校验构建。
 
-## License
+## 许可证
 
-@rc-component/np is released under the [MIT](./LICENSE) license.
+@rc-component/np 基于 [MIT](./LICENSE) 协议发布。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
   </p>
 </div>
 
-<p align="center">简体中文 | [English](./README.md)</p>
+<p align="center">简体中文 | <a href="./README.md">English</a></p>
 
 ## 亮点
 
@@ -43,18 +43,20 @@ npx rc-np
 ## 本地开发
 
 ```bash
-npm install
+ut install
 npm run compile
 npm run test:only
 ```
 
 ## 发布
 
+维护者发布此包前可以运行发布校验：
+
 ```bash
 npm run prepublishOnly
 ```
 
-这个包本身就是发布辅助工具，`prepublishOnly` 只在发布前校验构建。
+这个包本身就是发布辅助工具，所以发布校验只检查构建产物。
 
 ## 许可证
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rc-component/np",
   "version": "1.0.4",
-  "description": "publish tools for version bumping and changelog generation",
+  "description": "🚀 Release helper for rc-component packages.",
   "keywords": [
     "publish"
   ],
@@ -31,7 +31,7 @@
     "compile": "father build",
     "prepublishOnly": "npm run compile",
     "test": "npm run compile && npm run test:only",
-    "test:only": "node ./bin/np.mjs"
+    "test:only": "jest --runInBand"
   },
   "dependencies": {
     "@inquirer/prompts": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -35,24 +35,24 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^7.2.3",
-    "babel-jest": "^29.7.0",
+    "babel-jest": "^30.4.1",
     "chalk": "^4.1.2",
     "escape-goat": "^4.0.0",
     "fs-extra": "^10.1.0",
-    "jest": "^29.2.1",
+    "jest": "^30.4.2",
     "open": "^10.1.0",
     "semver": "^7.6.3",
     "simple-git": "^3.27.0",
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
-    "@types/fs-extra": "^9.0.13",
-    "@types/jest": "^29.2.0",
-    "@types/node": "^22.7.5",
-    "eslint": "^7.18.0",
-    "father": "^4.0.0",
-    "prettier": "^2.1.2",
-    "typescript": "^5.0.0"
+    "@types/fs-extra": "^11.0.4",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^26.0.1",
+    "eslint": "^9.39.4",
+    "father": "^4.6.24",
+    "prettier": "^3.9.4",
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=18.x"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "compile": "father build",
     "prepublishOnly": "npm run compile",
     "test": "npm run compile && npm run test:only",
-    "test:only": "jest --runInBand"
+    "test:only": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand"
   },
   "dependencies": {
     "@inquirer/prompts": "^7.2.3",


### PR DESCRIPTION
## Summary

- Refresh README and README.zh-CN with centered heading, badges, Ant Design ecosystem branding, install, usage, development, release, and license sections.
- Align Funding, grouped Dependabot updates, CodeQL, and CI workflow configuration.
- Align release documentation and scripts with `@rc-component/np` where applicable.

Refs ant-design/ant-design#58514

## Test

- `npm run compile`\n- `npm test`\n- `git diff --check`
- JSON parse check for package/config files
- README consistency scan
